### PR TITLE
fix: force building base image

### DIFF
--- a/nixopsvbox/backends/virtualbox.py
+++ b/nixopsvbox/backends/virtualbox.py
@@ -405,6 +405,7 @@ class VirtualBoxState(MachineState[VirtualBoxDefinition]):
                             checkConfigurationOptions=False,
                             attr='nodes."{0}".config.deployment.virtualbox.disks.{1}.baseImage'.format(self.name, disk_name),
                             pluginNixExprs=PluginManager.nixexprs(),
+                            build=True,
                         )
                     self._logged_exec(
                         [


### PR DESCRIPTION
Without this fix, the virtualbox disk may not exist when creating the machine.

The error is:

```
machine-1.> VBoxManage: error: Could not find file for the medium '/nix/store/7xgrcfcmcbhwb1bjcs4nq4dr2lh3mi3n-virtualbox-nixops-22.05.vmdk' (VERR_FILE_NOT_FOUND)
machine-1.> VBoxManage: error: Details: code VBOX_E_FILE_ERROR (0x80bb0004), component MediumWrap, interface IMedium, callee nsISupports
machine-1.> VBoxManage: error: Context: "OpenMedium(Bstr(pszFilenameOrUuid).raw(), enmDevType, enmAccessMode, fForceNewUuidOnOpen, pMedium.asOutParam())" at line 187 of file VBoxManageDisk.cpp
Traceback (most recent call last):
  File "/nix/store/ywh9crwf21xbhgw31fy5zpcc4z9p9gzb-python3-3.8.9-env/lib/python3.8/site-packages/nixops/parallel.py", line 70, in thread_fun
    work_result = (worker_fun(t), None, t.name)
  File "/nix/store/ywh9crwf21xbhgw31fy5zpcc4z9p9gzb-python3-3.8.9-env/lib/python3.8/site-packages/nixops/deployment.py", line 1207, in worker
    r.create(
  File "/nix/store/ywh9crwf21xbhgw31fy5zpcc4z9p9gzb-python3-3.8.9-env/lib/python3.8/site-packages/nixopsvbox/backends/virtualbox.py", line 409, in create
    self._logged_exec(
  File "/nix/store/ywh9crwf21xbhgw31fy5zpcc4z9p9gzb-python3-3.8.9-env/lib/python3.8/site-packages/nixops/backends/__init__.py", line 582, in _logged_exec
    return nixops.util.logged_exec(command, self.logger, **kwargs)
  File "/nix/store/ywh9crwf21xbhgw31fy5zpcc4z9p9gzb-python3-3.8.9-env/lib/python3.8/site-packages/nixops/util.py", line 372, in logged_exec
    raise CommandFailed(err, res)
nixops.util.CommandFailed: command ‘['VBoxManage', 'clonehd', '/nix/store/7xgrcfcmcbhwb1bjcs4nq4dr2lh3mi3n-virtualbox-nixops-22.05.vmdk', '/var/home/yajo/VirtualBox VMs/nixops-94a4598f-fdde-11ec-968b-b025aa45f949-k3s-agent-1/disk1.vdi', '--format', 'VDI']’ failed on machine ‘k3s-agent-1’ (exit code 1)
```

See https://github.com/nix-community/nixops-vbox/pull/28#issuecomment-1177446597.

For this to work, we need https://github.com/NixOS/nixops/pull/1529.

@moduon MT-904